### PR TITLE
Meta: Disallow crawling by Google-Extended

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,5 @@
+User-agent: *
+Allow: /
+
+User-agent: Google-Extended
+Disallow: /


### PR DESCRIPTION
Disallows crawling by Google-Extended, Google’s crawler for content to be fed into artificial intelligence training data